### PR TITLE
Fixing IDENTITY-5878, NullPointerException at RampartReceiver

### DIFF
--- a/modules/rampart-core/src/main/java/org/apache/rampart/handler/RampartReceiver.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/handler/RampartReceiver.java
@@ -25,6 +25,7 @@ import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.description.HandlerDescription;
 import org.apache.axis2.description.Parameter;
+import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.axis2.engine.Handler;
 import org.apache.axis2.namespace.Constants;
 import org.apache.commons.logging.Log;
@@ -42,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
-
 import javax.xml.namespace.QName;
 
 /**
@@ -179,8 +179,7 @@ public class RampartReceiver implements Handler {
         if (soapVersionURI.equals(SOAP11Constants.SOAP_ENVELOPE_NAMESPACE_URI) ) {
 
             String standardMsg = e.getMessage();
-            Parameter parameter = msgContext.getAxisMessage().getAxisConfiguration()
-                    .getParameter(INCLUDE_FULL_WSSECURITYEXCEPTION_MESSAGE);
+            Parameter parameter = getParameter(msgContext, INCLUDE_FULL_WSSECURITYEXCEPTION_MESSAGE);
             if (parameter == null
                     || (parameter != null
                         && parameter.getValue() instanceof String
@@ -199,8 +198,7 @@ public class RampartReceiver implements Handler {
             List subfaultCodes = new ArrayList();
             subfaultCodes.add(faultCode);
             String standardMsg = e.getMessage();
-            Parameter parameter = msgContext.getAxisMessage().getAxisConfiguration()
-                    .getParameter(INCLUDE_FULL_WSSECURITYEXCEPTION_MESSAGE);
+            Parameter parameter = getParameter(msgContext, INCLUDE_FULL_WSSECURITYEXCEPTION_MESSAGE);
             if (parameter == null
                     || (parameter != null
                     && parameter.getValue() instanceof String
@@ -218,4 +216,24 @@ public class RampartReceiver implements Handler {
 
     }
 
+    /**
+     * Returns the Parameter value for the given parameter name from available scope.
+     *
+     * @param msgContext The message context.
+     * @param paramName  The name of the parameter
+     * @return looked up parameter if it is available in the axis configuration. null if not found.
+     */
+    private Parameter getParameter(MessageContext msgContext, String paramName) {
+        AxisConfiguration axisConfiguration = null;
+        if (msgContext.getAxisMessage() != null) {
+            axisConfiguration = msgContext.getAxisMessage().getAxisConfiguration();
+        }
+        if (axisConfiguration == null && msgContext.getConfigurationContext() != null) {
+            axisConfiguration = msgContext.getConfigurationContext().getAxisConfiguration();
+        }
+        if (axisConfiguration != null) {
+            return axisConfiguration.getParameter(paramName);
+        }
+        return null;
+    }
 }

--- a/modules/rampart-tests/src/test/java/org/apache/rampart/RampartReceiverTest.java
+++ b/modules/rampart-tests/src/test/java/org/apache/rampart/RampartReceiverTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.rampart;
+
+import junit.framework.TestCase;
+import org.apache.axiom.soap.impl.builder.StAXSOAPModelBuilder;
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.client.Options;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.MessageContext;
+import org.apache.axis2.context.ServiceContext;
+import org.apache.axis2.context.ServiceGroupContext;
+import org.apache.axis2.description.AxisModule;
+import org.apache.axis2.description.AxisService;
+import org.apache.axis2.description.AxisServiceGroup;
+import org.apache.axis2.description.OutInAxisOperation;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.engine.Handler;
+import org.apache.neethi.PolicyReference;
+import org.apache.rampart.handler.RampartReceiver;
+
+import java.io.FileInputStream;
+import javax.xml.namespace.QName;
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+public class RampartReceiverTest extends TestCase {
+
+    public void testInvokeWithoutAxisMessage_NoSecurityHeader() throws Exception {
+        RampartReceiver rampartReceiver = new RampartReceiver();
+        MessageContext messageContext = initMsgCtxFromMessage("test-resources/policy/soapmessage-no-wss-header.xml");
+
+        try {
+            Handler.InvocationResponse invocationResponse = rampartReceiver.invoke(messageContext);
+
+            fail("Should throw a security exception when called without security header");
+        } catch (AxisFault af) {
+            assertEquals("Missing wsse:Security header in request", af.getMessage());
+        }
+    }
+
+    public void testInvokeWithoutAxisMessage_WithSecurityHeader() throws Exception {
+        RampartReceiver rampartReceiver = new RampartReceiver();
+        MessageContext messageContext = initMsgCtxFromMessage("test-resources/policy/soapmessage-with-wss-header.xml");
+        rampartReceiver.invoke(messageContext);
+    }
+
+    /**
+     * @throws XMLStreamException
+     * @throws FactoryConfigurationError
+     * @throws AxisFault
+     */
+    private MessageContext initMsgCtxFromMessage(String messageResource) throws Exception {
+        MessageContext ctx = new MessageContext();
+
+        AxisConfiguration axisConfiguration = new AxisConfiguration();
+        PolicyReference policyReference = new PolicyReference();
+        policyReference.setURI(this.getClass().getClassLoader()
+                .getResource("./policy/rampart-policy-for-RampartReceiverTest.xml").toString());
+        axisConfiguration.getPolicySubject().attachPolicyComponent(policyReference);
+
+        AxisModule axismodule = new AxisModule();
+        axismodule.setArchiveName("rampart");
+        axisConfiguration.addModule(axismodule);
+        axisConfiguration.engageModule("rampart");
+
+        AxisService axisService = new AxisService("TestService");
+        axisConfiguration.addService(axisService);
+        AxisServiceGroup axisServiceGroup = new AxisServiceGroup();
+        axisConfiguration.addServiceGroup(axisServiceGroup);
+        ctx.setConfigurationContext(new ConfigurationContext(axisConfiguration));
+        axisServiceGroup.addService(axisService);
+        ServiceGroupContext gCtx = ctx.getConfigurationContext().createServiceGroupContext(axisServiceGroup);
+        ServiceContext serviceContext = gCtx.getServiceContext(axisService);
+        ctx.setServiceContext(serviceContext);
+        ctx.setAxisService(axisService);
+        OutInAxisOperation outInAxisOperation = new OutInAxisOperation(new QName("http://rampart.org", "test"));
+        ctx.setAxisOperation(outInAxisOperation);
+        Options options = new Options();
+        options.setAction("urn:testOperation");
+        ctx.setOptions(options);
+
+        XMLStreamReader reader = XMLInputFactory.newInstance().
+                createXMLStreamReader(new FileInputStream(messageResource));
+        ctx.setEnvelope(new StAXSOAPModelBuilder(reader, null).getSOAPEnvelope());
+
+        return ctx;
+    }
+
+}

--- a/modules/rampart-tests/test-resources/policy/rampart-policy-for-RampartReceiverTest.xml
+++ b/modules/rampart-tests/test-resources/policy/rampart-policy-for-RampartReceiverTest.xml
@@ -1,0 +1,85 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<wsp:Policy wsu:Id="UTOverTransportTest"
+            xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+    <wsp:ExactlyOne>
+        <wsp:All>
+            <sp:AsymmetricBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+                <wsp:Policy>
+                    <sp:InitiatorToken>
+                        <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                        </wsp:Policy>
+                    </sp:InitiatorToken>
+                    <sp:RecipientToken>
+                        <wsp:Policy>
+                            <sp:HttpsToken RequireClientCertificate="false"/>
+                        </wsp:Policy>
+                    </sp:RecipientToken>
+                    <sp:AlgorithmSuite>
+                        <wsp:Policy>
+                            <sp:Basic256/>
+                        </wsp:Policy>
+                    </sp:AlgorithmSuite>
+                    <sp:Layout>
+                        <wsp:Policy>
+                            <sp:Lax/>
+                        </wsp:Policy>
+                    </sp:Layout>
+                    <sp:IncludeTimestamp wsp:Optional="true" />
+
+                </wsp:Policy>
+            </sp:AsymmetricBinding>
+            <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+                <wsp:Policy>
+                    <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient"/>
+                </wsp:Policy>
+            </sp:SignedSupportingTokens>
+        </wsp:All>
+    </wsp:ExactlyOne>
+    <ramp:RampartConfig xmlns:ramp="http://ws.apache.org/rampart/policy">
+        <ramp:user>alice</ramp:user>
+        <ramp:encryptionUser>bob</ramp:encryptionUser>
+        <ramp:passwordCallbackClass>org.apache.rampart.TestCBHandler</ramp:passwordCallbackClass>
+
+        <ramp:signatureCrypto>
+            <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
+                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">JKS</ramp:property>
+                <ramp:property name="org.apache.ws.security.crypto.merlin.file">test-resources/keys/interop2.jks</ramp:property>
+                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">password</ramp:property>
+            </ramp:crypto>
+        </ramp:signatureCrypto>
+    </ramp:RampartConfig>
+    <!--<rampart:RampartConfig xmlns:rampart="http://ws.apache.org/rampart/policy">-->
+        <!--<rampart:user>wso2carbon</rampart:user>-->
+        <!--<rampart:encryptionUser>useReqSigCert</rampart:encryptionUser>-->
+        <!--<rampart:timestampPrecisionInMilliseconds>true</rampart:timestampPrecisionInMilliseconds>-->
+        <!--<rampart:timestampTTL>300</rampart:timestampTTL>-->
+        <!--<rampart:timestampMaxSkew>300</rampart:timestampMaxSkew>-->
+        <!--<rampart:timestampStrict>false</rampart:timestampStrict>-->
+        <!--&lt;!&ndash;<rampart:tokenStoreClass>org.apache.rahas.SimpleTokenStore</rampart:tokenStoreClass>&ndash;&gt;-->
+        <!--<rampart:nonceLifeTime>300</rampart:nonceLifeTime>-->
+    <!--</rampart:RampartConfig>-->
+    <sec:CarbonSecConfig xmlns:sec="http://www.wso2.org/products/carbon/security">
+        <sec:Authorization>
+            <sec:property name="org.wso2.carbon.security.allowedroles">c_mpass_registru_rsp</sec:property>
+        </sec:Authorization>
+    </sec:CarbonSecConfig>
+</wsp:Policy>
+

--- a/modules/rampart-tests/test-resources/policy/soapmessage-no-wss-header.xml
+++ b/modules/rampart-tests/test-resources/policy/soapmessage-no-wss-header.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                  xmlns:axis2="http://ws.apache.org/namespaces/axis2">
+    <soapenv:Header xmlns:fabrikam="http://example.com/fabrikam">
+
+    </soapenv:Header>
+    <soapenv:Body>
+        <ns1:getBalance soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                        xmlns:ns1="http://localhost:8081/axis/services/BankPort">
+            <accountNo href="#id0"/>
+        </ns1:getBalance>
+        <multiRef id="id0" soapenc:root="0"
+                  soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                  xsi:type="xsd:int" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+            1001</multiRef>
+    </soapenv:Body>
+</soapenv:Envelope>

--- a/modules/rampart-tests/test-resources/policy/soapmessage-with-wss-header.xml
+++ b/modules/rampart-tests/test-resources/policy/soapmessage-with-wss-header.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                  xmlns:axis2="http://ws.apache.org/namespaces/axis2">
+    <soapenv:Header xmlns:fabrikam="http://example.com/fabrikam">
+        <wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                       wsu:Id="Timestamp-1">
+            <wsu:Created>2012-06-01T15:09:12.520Z</wsu:Created>
+            <wsu:Expires>2112-06-01T15:14:12.520Z</wsu:Expires>
+        </wsu:Timestamp>
+        <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+            <wsse:UsernameToken>
+                <wsse:Username>alice</wsse:Username>
+                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">ACngE6DX8ZbqWe+gUYHfYzoFTwI=</wsse:Password>
+                <wsse:Nonce>MQ==</wsse:Nonce>
+                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2017-04-16T01:24:32Z</wssu:Created>
+            </wsse:UsernameToken>
+        </wsse:Security>
+        <wsa:To>http://localhost:9001/services/SecureStockQuoteService</wsa:To>
+        <wsa:MessageID>urn:uuid:1C4CE88B8A1A9C09D91177500753443</wsa:MessageID>
+        <wsa:Action>urn:testOperation</wsa:Action>
+    </soapenv:Header>
+    <soapenv:Body>
+        <ns1:getBalance soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                        xmlns:ns1="http://localhost:8081/axis/services/BankPort">
+            <accountNo href="#id0"/>
+        </ns1:getBalance>
+        <multiRef id="id0" soapenc:root="0"
+                  soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                  xsi:type="xsd:int" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+            1001</multiRef>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Fixing IDENTITY-5878, NullPointerException at RampartReceiver, when WSS header not present and SOAPAction not present in SOAP 1.1