### PR TITLE
Revert "Add TTL validation for incoming SOAP messages"

### DIFF
--- a/modules/rampart-core/src/main/java/org/apache/rampart/RampartEngine.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/RampartEngine.java
@@ -218,16 +218,9 @@ public class RampartEngine {
                     	DocumentBuilderFactoryImpl.setDOOMRequired(true);
                 }
 			}
-
-            if (rmd.isIncomingTTLCheck()) {
-                results = engine.processSecurityHeader(rmd.getDocument(), actorValue,
-                        tokenCallbackHandler, signatureCrypto, RampartUtil.getEncryptionCrypto(
-                                rpd.getRampartConfig(), msgCtx.getAxisService().getClassLoader()), rmd.getTimeToLive());
-            } else {
-                results = engine.processSecurityHeader(rmd.getDocument(), actorValue,
-                        tokenCallbackHandler, signatureCrypto, RampartUtil.getEncryptionCrypto(
-                                rpd.getRampartConfig(), msgCtx.getAxisService().getClassLoader()));
-            }
+            results = engine.processSecurityHeader(rmd.getDocument(), actorValue,
+                    tokenCallbackHandler, signatureCrypto, RampartUtil.getEncryptionCrypto(
+							rpd.getRampartConfig(), msgCtx.getAxisService().getClassLoader()));
 
 			if (rpd.getInitiatorToken() instanceof IssuedToken) {
 				String tokenType = ((IssuedToken) rpd.getInitiatorToken()).getRstTokenType();

--- a/modules/rampart-core/src/main/java/org/apache/rampart/RampartMessageData.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/RampartMessageData.java
@@ -123,8 +123,6 @@ public class RampartMessageData {
     private int timeToLive = 300;
     
     private int timestampMaxSkew = 0;
-
-    private boolean incomingTTLCheck = false;
     
     private String timestampId;
     
@@ -305,11 +303,6 @@ public class RampartMessageData {
                     String maxSkewString = policyDataRampartConfig.getTimestampMaxSkew();
                     if (maxSkewString != null && !maxSkewString.equals("")) {
                         this.setTimestampMaxSkew(Integer.parseInt(maxSkewString));
-                    }
-
-                    String enableTTL = policyDataRampartConfig.getEnableTTLCheck();
-                    if (enableTTL != null && !enableTTL.equals("")) {
-                        this.setIncomingTTLCheck(Boolean.parseBoolean(enableTTL));
                     }
                 }
                 
@@ -522,14 +515,6 @@ public class RampartMessageData {
      */
     public void setTimeToLive(int timeToLive) {
         this.timeToLive = timeToLive;
-    }
-
-    public boolean isIncomingTTLCheck() {
-        return incomingTTLCheck;
-    }
-
-    public void setIncomingTTLCheck(boolean incomingTTLCheck) {
-        this.incomingTTLCheck = incomingTTLCheck;
     }
 
     /**

--- a/modules/rampart-core/src/main/java/org/apache/rampart/policy/builders/RampartConfigBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/policy/builders/RampartConfigBuilder.java
@@ -180,12 +180,6 @@ public class RampartConfigBuilder implements AssertionBuilder {
         }
 
         childElement = element.getFirstChildWithName(new QName(
-                RampartConfig.NS, RampartConfig.TS_ENABLE_TTL_CHECK_LN));
-        if (childElement != null) {
-            rampartConfig.setEnableTTLCheck(childElement.getText().trim());
-        }
-
-        childElement = element.getFirstChildWithName(new QName(
                 RampartConfig.NS, RampartConfig.OPTIMIZE_MSG_PROCESSING_TRANSPORT_BINDING));
         if (childElement != null) {
             rampartConfig.setOptimizeMessageProcessingForTransportBinding(

--- a/modules/rampart-core/src/main/java/org/apache/rampart/policy/model/RampartConfig.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/policy/model/RampartConfig.java
@@ -38,7 +38,6 @@ import java.util.Map;
  *  &lt;ramp:policyValidatorCbClass&gt;org.apache.axis2.security.ramp:PolicyValidatorCallbackHandler&lt;/ramp:policyValidatorCbClass&gt;
  *  &lt;ramp:timestampPrecisionInMilliseconds&gt;true&lt;/timestampPrecisionInMilliseconds&gt;
  *  &lt;ramp:timestampTTL&gt;300&lt;/ramp:timestampTTL&gt;
- *  &lt;ramp:enableTTLCheck&gt;true&lt;/ramp:enableTTLCheck&gt;
  *  &lt;ramp:timestampMaxSkew&gt;0&lt;/ramp:timestampMaxSkew&gt;
  *  &lt;ramp:tokenStoreClass&gt;org.apache.rahas.StorageImpl&lt;/ramp:tokenStoreClass&gt;
  *  &lt;ramp:nonceLifeTime&gt;org.apache.rahas.StorageImpl&lt;/ramp:nonceLifeTime&gt;
@@ -72,8 +71,6 @@ public class RampartConfig implements Assertion {
 
     public static final int DEFAULT_NONCE_LIFE_TIME = 60 * 5; // Default life time of a nonce is 5
                                                               // minutes
-
-    public static final boolean DEFAULT_ENABLE_TTL_CHECK = false;
 
     public final static String NS = "http://ws.apache.org/rampart/policy";
 
@@ -116,8 +113,6 @@ public class RampartConfig implements Assertion {
     public final static String TOKEN_STORE_CLASS_LN = "tokenStoreClass";
 
     public final static String TIMESTAMP_STRICT_LN = "timestampStrict";
-
-    public final static String TS_ENABLE_TTL_CHECK_LN = "enableTTLCheck";
 
     public final static String NONCE_LIFE_TIME = "nonceLifeTime";
 
@@ -176,9 +171,6 @@ public class RampartConfig implements Assertion {
 
         /*To set timeStampStrict in WSSConfig through rampartConfig*/
     private String timeStampStrict = Boolean.toString(TIMESTAMP_STRICT);
-
-    // By default TTL check will be disabled
-    private String enableTTLCheck = Boolean.toString(DEFAULT_ENABLE_TTL_CHECK);
 
     private KerberosConfig kerberosConfig;
 
@@ -431,12 +423,6 @@ public class RampartConfig implements Assertion {
             writer.writeEndElement();
         }
 
-        if (getEnableTTLCheck() != null) {
-            writer.writeStartElement(NS, TS_ENABLE_TTL_CHECK_LN);
-            writer.writeCharacters(getEnableTTLCheck());
-            writer.writeEndElement();
-        }
-
         if (getTokenStoreClass() != null) {
             writer.writeStartElement(NS, TOKEN_STORE_CLASS_LN);
             writer.writeCharacters(getTokenStoreClass());
@@ -576,11 +562,4 @@ public class RampartConfig implements Assertion {
         this.timeStampStrict = timeStampStrict;
     }
 
-    public String getEnableTTLCheck() {
-        return enableTTLCheck;
-    }
-
-    public void setEnableTTLCheck(String enableTTLCheck) {
-        this.enableTTLCheck = enableTTLCheck;
-    }
 }


### PR DESCRIPTION
Reverts wso2/wso2-rampart#69

Reverting temporary until wso2/wso2-wss4j released, as the PR has a dependency on wso2/wso2-wss4j#45