### PR TITLE
Upgrade wss4j and opensaml version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -536,11 +536,11 @@
         <axis2.version>1.6.1-wso2v17</axis2.version>
         <axiom.version>1.2.11-wso2v10</axiom.version>
 
-        <wss4j.version>1.5.11-wso2v17</wss4j.version>
+        <wss4j.version>1.5.11-wso2v18</wss4j.version>
         <xmlsec.version>1.4.2</xmlsec.version>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <neethi.version>2.0.4.wso2v5</neethi.version>
-        <opensaml.version>2.2.3</opensaml.version>
+        <opensaml.version>2.6.4</opensaml.version>
         <opensaml1.version>1.1</opensaml1.version>
 
         <junit.version>3.8.2</junit.version>


### PR DESCRIPTION
## Purpose
> Upgrade wso2-wss4j and opensaml versions.

Please merge after releasing wso2-wss4j 1.5.11-wso2v18 version.

Upgraded opensaml version due to conflicting slf4j.jdk14 versions.

- wso2-wss4j 1.5.11-wso2v18 uses slf4j.jdk14 1.7.26 version and
- opensaml 2.2.3 uses an older slf4j.jdk14 version.