### PR TITLE
Embed OpenSAML2 dependencies

### DIFF
--- a/orbit/rampart-core/pom.xml
+++ b/orbit/rampart-core/pom.xml
@@ -148,6 +148,18 @@
             <artifactId>opensaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>xmltooling</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>openws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.esapi</groupId>
+            <artifactId>esapi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -196,12 +208,14 @@
                             org.apache.ws.secpolicy.model; version="${imp.pkg.version.range.rampart}",
                             org.apache.xml.security.utils; version="${imp.pkg.version.xmlsec}",
                             org.jaxen, org.joda.time,
-                            org.opensaml,
-                            org.opensaml.saml2.core,
-                            org.opensaml.xml,
                             org.w3c.dom
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Embed-Dependency>
+                            opensaml;inline=false, opensaml1;inline=false, xmltooling;inline=false,
+                            openws;inline=false, esapi;inline=false
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
                 </configuration>
             </plugin>

--- a/orbit/rampart-trust/pom.xml
+++ b/orbit/rampart-trust/pom.xml
@@ -51,6 +51,18 @@
             <artifactId>opensaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>xmltooling</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>openws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.esapi</groupId>
+            <artifactId>esapi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -179,17 +191,6 @@
                             org.apache.xml.security.keys.content.x509; version="${imp.pkg.version.xmlsec}",
                             org.apache.xml.security.utils; version="${imp.pkg.version.xmlsec}",
                             org.joda.time,
-                            org.opensaml,
-                            org.opensaml.common,
-                            org.opensaml.saml2.core,
-                            org.opensaml.saml2.core.impl,
-                            org.opensaml.xml,
-                            org.opensaml.xml.io,
-                            org.opensaml.xml.schema,
-                            org.opensaml.xml.schema.impl,
-                            org.opensaml.xml.security.credential,
-                            org.opensaml.xml.security.x509,
-                            org.opensaml.xml.signature,
                             org.w3c.dom,
                             org.w3c.dom.bootstrap,
                             org.w3c.dom.ls,
@@ -199,6 +200,11 @@
                             !org.wso2.carbon
                         </Private-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Embed-Dependency>
+                            opensaml;inline=false, opensaml1;inline=false, xmltooling;inline=false,
+                            openws;inline=false, esapi;inline=false
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
         <axis2.version>1.6.1-wso2v37</axis2.version>
         <axiom.version>1.2.11-wso2v16</axiom.version>
 
-        <wss4j.version>1.5.11-wso2v18</wss4j.version>
+        <wss4j.version>1.5.11-wso2v18-SNAPSHOT</wss4j.version>
         <xmlsec.version>1.4.2</xmlsec.version>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <neethi.version>2.0.4.wso2v5</neethi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,16 @@
                 <version>${opensaml.xmltooling.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>openws</artifactId>
+                <version>${openws.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.owasp.esapi</groupId>
+                <artifactId>esapi</artifactId>
+                <version>${esapi.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons.ssl</groupId>
                 <artifactId>not-yet-commons-ssl</artifactId>
                 <version>${commons.ssl.version}</version>
@@ -553,6 +563,8 @@
         <opensaml.version>2.6.6</opensaml.version>
         <opensaml.xmltooling.version>1.4.6</opensaml.xmltooling.version>
         <opensaml1.version>1.1</opensaml1.version>
+        <openws.version>1.5.4</openws.version>
+        <esapi.version>2.1.0.1</esapi.version>
         <commons.ssl.version>0.3.9</commons.ssl.version>
 
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
         <axis2.version>1.6.1-wso2v37</axis2.version>
         <axiom.version>1.2.11-wso2v16</axiom.version>
 
-        <wss4j.version>1.5.11-wso2v18-SNAPSHOT</wss4j.version>
+        <wss4j.version>1.5.11-wso2v19</wss4j.version>
         <xmlsec.version>1.4.2</xmlsec.version>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <neethi.version>2.0.4.wso2v5</neethi.version>


### PR DESCRIPTION
## Purpose
- To remove exposure of OpenSAML2 dependencies to product-is

## Goals
- Embed the required OpenSAML2 dependencies.

## Prerequisites
- https://github.com/wso2/wso2-wss4j/pull/80 - wss4j with embedded OpenSAML2 dependencies.