### PR TITLE
Remove embedded OpenSAML2 dependencies.

### DIFF
--- a/orbit/rampart-core/pom.xml
+++ b/orbit/rampart-core/pom.xml
@@ -148,18 +148,6 @@
             <artifactId>opensaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>xmltooling</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>openws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.owasp.esapi</groupId>
-            <artifactId>esapi</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -208,14 +196,12 @@
                             org.apache.ws.secpolicy.model; version="${imp.pkg.version.range.rampart}",
                             org.apache.xml.security.utils; version="${imp.pkg.version.xmlsec}",
                             org.jaxen, org.joda.time,
+                            org.opensaml,
+                            org.opensaml.saml2.core,
+                            org.opensaml.xml,
                             org.w3c.dom
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
-                        <Embed-Dependency>
-                            opensaml;inline=false, opensaml1;inline=false, xmltooling;inline=false,
-                            openws;inline=false, esapi;inline=false
-                        </Embed-Dependency>
-                        <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
                 </configuration>
             </plugin>

--- a/orbit/rampart-trust/pom.xml
+++ b/orbit/rampart-trust/pom.xml
@@ -51,18 +51,6 @@
             <artifactId>opensaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>xmltooling</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>openws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.owasp.esapi</groupId>
-            <artifactId>esapi</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -191,6 +179,17 @@
                             org.apache.xml.security.keys.content.x509; version="${imp.pkg.version.xmlsec}",
                             org.apache.xml.security.utils; version="${imp.pkg.version.xmlsec}",
                             org.joda.time,
+                            org.opensaml,
+                            org.opensaml.common,
+                            org.opensaml.saml2.core,
+                            org.opensaml.saml2.core.impl,
+                            org.opensaml.xml,
+                            org.opensaml.xml.io,
+                            org.opensaml.xml.schema,
+                            org.opensaml.xml.schema.impl,
+                            org.opensaml.xml.security.credential,
+                            org.opensaml.xml.security.x509,
+                            org.opensaml.xml.signature,
                             org.w3c.dom,
                             org.w3c.dom.bootstrap,
                             org.w3c.dom.ls,
@@ -200,11 +199,6 @@
                             !org.wso2.carbon
                         </Private-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
-                        <Embed-Dependency>
-                            opensaml;inline=false, opensaml1;inline=false, xmltooling;inline=false,
-                            openws;inline=false, esapi;inline=false
-                        </Embed-Dependency>
-                        <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -409,16 +409,6 @@
                 <version>${opensaml.xmltooling.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.opensaml</groupId>
-                <artifactId>openws</artifactId>
-                <version>${openws.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.owasp.esapi</groupId>
-                <artifactId>esapi</artifactId>
-                <version>${esapi.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons.ssl</groupId>
                 <artifactId>not-yet-commons-ssl</artifactId>
                 <version>${commons.ssl.version}</version>
@@ -556,15 +546,13 @@
         <axis2.version>1.6.1-wso2v37</axis2.version>
         <axiom.version>1.2.11-wso2v16</axiom.version>
 
-        <wss4j.version>1.5.11-wso2v19</wss4j.version>
+        <wss4j.version>1.5.11-wso2v20-SNAPSHOT</wss4j.version>
         <xmlsec.version>1.4.2</xmlsec.version>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <neethi.version>2.0.4.wso2v5</neethi.version>
         <opensaml.version>2.6.6</opensaml.version>
         <opensaml.xmltooling.version>1.4.6</opensaml.xmltooling.version>
         <opensaml1.version>1.1</opensaml1.version>
-        <openws.version>1.5.4</openws.version>
-        <esapi.version>2.1.0.1</esapi.version>
         <commons.ssl.version>0.3.9</commons.ssl.version>
 
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@
         <axis2.version>1.6.1-wso2v37</axis2.version>
         <axiom.version>1.2.11-wso2v16</axiom.version>
 
-        <wss4j.version>1.5.11-wso2v20-SNAPSHOT</wss4j.version>
+        <wss4j.version>1.5.11-wso2v20</wss4j.version>
         <xmlsec.version>1.4.2</xmlsec.version>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <neethi.version>2.0.4.wso2v5</neethi.version>


### PR DESCRIPTION
- Remove embedded OpenSAML2 dependencies to fix ws-trust scenarios.