### PR TITLE
Allow multiple Audience values on passive STS SAML Assertions

### DIFF
--- a/modules/rampart-trust/pom.xml
+++ b/modules/rampart-trust/pom.xml
@@ -89,6 +89,16 @@
             <groupId>xerces.wso2</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
     </dependencies>
 
     <reporting>
@@ -102,5 +112,11 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <properties>
+
+        <carbon.identity.framework.version>5.20.28</carbon.identity.framework.version>
+
+    </properties>
 
 </project>

--- a/modules/rampart-trust/pom.xml
+++ b/modules/rampart-trust/pom.xml
@@ -92,12 +92,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.common</artifactId>
-            <version>${carbon.identity.framework.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
-            <version>${carbon.identity.framework.version}</version>
         </dependency>
     </dependencies>
 
@@ -112,11 +110,5 @@
             </plugin>
         </plugins>
     </reporting>
-
-    <properties>
-
-        <carbon.identity.framework.version>5.20.28</carbon.identity.framework.version>
-
-    </properties>
 
 </project>

--- a/modules/rampart-trust/pom.xml
+++ b/modules/rampart-trust/pom.xml
@@ -89,14 +89,6 @@
             <groupId>xerces.wso2</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
-        </dependency>
     </dependencies>
 
     <reporting>

--- a/modules/rampart-trust/pom.xml
+++ b/modules/rampart-trust/pom.xml
@@ -89,6 +89,14 @@
             <groupId>xerces.wso2</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+        </dependency>
     </dependencies>
 
     <reporting>
@@ -98,7 +106,6 @@
                 <artifactId>maven-site-plugin</artifactId>
                 <configuration>
                     <templateDirectory>${basedir}</templateDirectory>
-                    <menu ref="parent" />
                 </configuration>
             </plugin>
         </plugins>

--- a/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
+++ b/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
@@ -232,16 +232,19 @@ public class SAML2TokenIssuer implements TokenIssuer {
             Conditions conditions = new ConditionsBuilder().buildObject();
 			conditions.setNotBefore(creationDate);
 			conditions.setNotOnOrAfter(expirationDate);
-
+            log.debug(">>>>>>> Processing audiences");
 			if (data.getAppliesToAddress() != null) {
 				AudienceRestriction audienceRestriction = new AudienceRestrictionBuilder()
 						.buildObject();
 				Audience issuerAudience = new AudienceBuilder().buildObject();
+				Audience additionalAudience = new AudienceBuilder().buildObject();
 				issuerAudience.setAudienceURI(data.getAppliesToAddress());
+                additionalAudience.setAudienceURI("https://test.aditional.audience.com/");
 				audienceRestriction.getAudiences().add(issuerAudience);
+                audienceRestriction.getAudiences().add(additionalAudience);
 				conditions.getAudienceRestrictions().add(audienceRestriction);
 			}
-			
+            log.debug(">>>>>>> Finished processing audiences");
 			assertion.setConditions(conditions);
 
 			// Set the issued time.

--- a/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
+++ b/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
@@ -569,8 +569,9 @@ public class SAML2TokenIssuer implements TokenIssuer {
                 buildObject(SubjectConfirmationData.DEFAULT_ELEMENT_NAME, KeyInfoConfirmationDataType.TYPE_NAME);
 
         //Set the keyInfo element
-        if (keyInfoElement != null)
+        if (keyInfoElement != null) {
             scData.getKeyInfos().add(keyInfoElement);
+        }
 
         // Set the validity period
         scData.setNotBefore(creationTime);

--- a/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
+++ b/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
@@ -141,7 +141,7 @@ public class SAML2TokenIssuer implements TokenIssuer {
             }
         }
     
-    public SOAPEnvelope issue(RahasData data) {
+    public SOAPEnvelope issue(RahasData data) throws TrustException {
         MessageContext inMsgCtx = data.getInMessageContext();
 
         try {

--- a/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAMLTokenIssuer.java
+++ b/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAMLTokenIssuer.java
@@ -48,7 +48,6 @@ import org.apache.ws.security.message.token.SecurityTokenReference;
 import org.apache.ws.security.util.Base64;
 import org.apache.ws.security.util.Loader;
 import org.apache.ws.security.util.XmlSchemaDateFormat;
-import org.apache.xml.security.signature.XMLSignature;
 import org.apache.xml.security.utils.EncryptionConstants;
 import org.opensaml.SAMLAssertion;
 import org.opensaml.SAMLAttribute;
@@ -60,10 +59,6 @@ import org.opensaml.SAMLException;
 import org.opensaml.SAMLNameIdentifier;
 import org.opensaml.SAMLStatement;
 import org.opensaml.SAMLSubject;
-import org.opensaml.saml2.core.Audience;
-import org.opensaml.saml2.core.AudienceRestriction;
-import org.opensaml.saml2.core.impl.AudienceBuilder;
-import org.opensaml.saml2.core.impl.AudienceRestrictionBuilder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -608,6 +603,12 @@ public class SAMLTokenIssuer implements TokenIssuer {
             if (StringUtils.isNotBlank(this.audienceRestriction)) {
                 SAMLAudienceRestrictionCondition audienceRestriction = new SAMLAudienceRestrictionCondition();
                 audienceRestriction.addAudience(this.audienceRestriction);
+
+                List<String> additionalAudiences =
+                        TokenIssuerUtil.getAdditionalSAMLAudiencesFromAssociatedServiceProvider(this.audienceRestriction);
+                for (String additionalAudience : additionalAudiences)
+                    audienceRestriction.addAudience(additionalAudience);
+
                 conditions = new ArrayList<SAMLCondition>();
                 conditions.add(audienceRestriction);
             }
@@ -684,6 +685,12 @@ public class SAMLTokenIssuer implements TokenIssuer {
             if (StringUtils.isNotBlank(this.audienceRestriction)) {
                 SAMLAudienceRestrictionCondition audienceRestriction = new SAMLAudienceRestrictionCondition();
                 audienceRestriction.addAudience(this.audienceRestriction);
+
+                List<String> additionalAudiences =
+                        TokenIssuerUtil.getAdditionalSAMLAudiencesFromAssociatedServiceProvider(this.audienceRestriction);
+                for (String additionalAudience : additionalAudiences)
+                    audienceRestriction.addAudience(additionalAudience);
+
                 conditions = new ArrayList<SAMLCondition>();
                 conditions.add(audienceRestriction);
             }

--- a/modules/rampart-trust/src/main/java/org/apache/rahas/impl/TokenIssuerUtil.java
+++ b/modules/rampart-trust/src/main/java/org/apache/rahas/impl/TokenIssuerUtil.java
@@ -282,13 +282,13 @@ public class TokenIssuerUtil {
 
         List<String> additionalAudiences = new ArrayList<String>(0);
 
-        if (issuerAddress != null && !issuerAddress.isEmpty()) {
+        if (StringUtils.isNotBlank(issuerAddress)) {
             try {
                 ApplicationDAO applicationDAO = new ApplicationDAOImpl();
                 String existingSPName = applicationDAO.getServiceProviderNameByClientId
-                        (issuerAddress,"wstrust", CarbonContext
+                        (issuerAddress, "wstrust", CarbonContext
                                 .getThreadLocalCarbonContext().getTenantDomain());
-                if (existingSPName != null && !existingSPName.isEmpty()) {
+                if (StringUtils.isNotBlank(existingSPName)) {
                     ServiceProvider serviceProvider = applicationDAO.getApplication(existingSPName, CarbonContext
                             .getThreadLocalCarbonContext().getTenantDomain());
                     InboundAuthenticationRequestConfig[] inboundAuthReqConfigs = serviceProvider

--- a/modules/rampart-trust/src/main/java/org/apache/rahas/impl/TokenIssuerUtil.java
+++ b/modules/rampart-trust/src/main/java/org/apache/rahas/impl/TokenIssuerUtil.java
@@ -19,6 +19,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.Base64;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.context.MessageContext;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.rahas.Rahas;

--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,14 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -473,14 +473,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.application.common</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,16 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -542,6 +552,7 @@
         <imp.pkg.version.range.rampart>[1.6.1,2.0.0)</imp.pkg.version.range.rampart>
         <rampart.mar.version>${rampart.version}</rampart.mar.version>
         <rahas.mar.version>${rampart.version}</rahas.mar.version>
+        <carbon.identity.framework.version>5.20.28</carbon.identity.framework.version>
 
         <axis2.version>1.6.1-wso2v37</axis2.version>
         <axiom.version>1.2.11-wso2v16</axiom.version>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to tackle the enhancement to the IS product on its 5.10.0 version, described in Git Issue #10960 (product-is): https://github.com/wso2/product-is/issues/10960

## Goals
Adds complementary logic to support the processing of multiple Condition/AudienceRestriction/Audience elements in the SAML 1.1 and 2.0 responses for the WS-Trust STS service implementation in the product-is

## Approach
The changes performed to this component does not introduce modifications to the UI. An utilitary method that calculates the different audiences (if any) that might have been added to a previously registered Service Provider (SP) is used by the SAML token generator classes. This method returns a list of strings with the Audience endpoints that belong on the same SP that would also have a registered Audience endpoint that matches the <appliesTo> URI value in the STS auth request from the relying party. Afterwards, this list is used to compile the proper set of Audience elements that should construct the SAML response. Note that the Audience elements in the SAML response will always include the corresponding URIs that are registered in the SP that complies with the abovementioned condition.

## User stories
See Git Issue #10960 (wso2/product-is) for more information on the use cases.

## Release note
Added support for multiple Audience elements in the SAML response for WS-Trust STS authentication requests

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
All tests were unitary and were performed through the use of the STS client application, see: https://is.docs.wso2.com/en/5.10.0/learn/running-an-sts-client/

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **YES**
 - Ran FindSecurityBugs plugin and verified report? **NO**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **YES**

## Samples
When a relying party (client application) performs an authentication attempt through the use of the WS-Trust STS service on the IDP, upon successful authentication, the IDP will generate and provide a SAML token containing a list of audiences associated with the URI endpoint, on which said token will have validity.

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/3397
- https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/103

## Migrations (if applicable)
N/A

## Test environment
Windows environment, JDK 8, sample STS client application, Chrome and Edge browsers.
 
## Learning
- SAML 2.0 specification: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf

- Introductions to WS-Trust: 

1. https://dinika-15.medium.com/ws-trust-and-security-token-service-sts-fd1c92a5f53c
2. https://is.docs.wso2.com/en/5.10.0/learn/ws-trust/

- Many misc. google searches.