### PR TITLE
Upgrade xmlsec version to 2.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@
         <axiom.version>1.2.11-wso2v16</axiom.version>
 
         <wss4j.version>1.5.11-wso2v20</wss4j.version>
-        <xmlsec.version>1.4.2</xmlsec.version>
+        <xmlsec.version>2.1.7</xmlsec.version>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <neethi.version>2.0.4.wso2v5</neethi.version>
         <opensaml.version>2.6.6</opensaml.version>
@@ -570,7 +570,7 @@
         <imp.pkg.version.javax.xml>1.0.1</imp.pkg.version.javax.xml>
         <imp.pkg.version.range.commons.logging>[1.0.4,2.0.0)</imp.pkg.version.range.commons.logging>
         <imp.pkg.version.range.xml.stream>[1.0.1,2.0.0)</imp.pkg.version.range.xml.stream>
-        <imp.pkg.version.xmlsec>[1.4.2, 2.0.0)</imp.pkg.version.xmlsec>
+        <imp.pkg.version.xmlsec>[2.1.7, 2.4.0)</imp.pkg.version.xmlsec>
         <commons-logging.version>1.1.1</commons-logging.version>
         <commons-lang.version>2.3</commons-lang.version>
         <felix-framework.version>1.0.3</felix-framework.version>


### PR DESCRIPTION
## Purpose
> Upgrade xmlsec version to 2.1.7 to resolve dependencies when starting up identity server with latest sts-connector built from identity-inbound-auth-sts 5.7.4-SNAPSHOT.

**Related Issue** 
https://github.com/wso2/product-is/issues/13717 