### PR TITLE
Update imp.pkg.version.xmlsec range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
         <imp.pkg.version.javax.xml>1.0.1</imp.pkg.version.javax.xml>
         <imp.pkg.version.range.commons.logging>[1.0.4,2.0.0)</imp.pkg.version.range.commons.logging>
         <imp.pkg.version.range.xml.stream>[1.0.1,2.0.0)</imp.pkg.version.range.xml.stream>
-        <imp.pkg.version.xmlsec>[2.1.7,2.4.0)</imp.pkg.version.xmlsec>
+        <imp.pkg.version.xmlsec>[1.4.2,2.4.0)</imp.pkg.version.xmlsec>
         <commons-logging.version>1.1.1</commons-logging.version>
         <commons-lang.version>2.3</commons-lang.version>
         <felix-framework.version>1.0.3</felix-framework.version>


### PR DESCRIPTION
## Purpose
This PR reverts the starting version of the `imp.pkg.version.xmlsec` range introduced in https://github.com/wso2/wso2-rampart/pull/112 to ensure compatibility with the micro-integrator-public build, which currently supports only `xmlsec` v1.x.x.
